### PR TITLE
Run presentLocalNotification on the UI thread

### DIFF
--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
@@ -213,7 +213,9 @@ RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)
 
 RCT_EXPORT_METHOD(presentLocalNotification:(UILocalNotification *)notification)
 {
-    [RCTSharedApplication() presentLocalNotificationNow:notification];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [RCTSharedApplication() presentLocalNotificationNow:notification];
+    });
 }
 
 + (BOOL)requiresMainQueueSetup


### PR DESCRIPTION
Xcode requires presentLocalNotification to be run on the UI thread. This
commit wraps the call in an async block to dispatch on the UI thread.