### PR TITLE
support store `completion` for invoke later

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,6 +136,21 @@ export default class RNVoipPushNotification {
     }
 
     /**
+     * When you have processed necessary initialization for voip push, tell ios completed.
+     * This is mainly for ios 11+, which apple required us to execute `complete()` when we finished.
+     * If you want to use this function, make sure you call `[RNVoipPushNotificationManager addCompletionHandler:uuid completionHandler:completion];`
+     *   in `didReceiveIncomingPushWithPayload` in your AppDelegate.m
+     *
+     * @static
+     * @memberof RNVoipPushNotification
+     * 
+     * uuid:
+     */
+    static onVoipNotificationCompleted(uuid) {
+        RNVoipPushNotificationManager.onVoipNotificationCompleted(uuid);
+    }
+
+    /**
      * You will never need to instantiate `RNVoipPushNotification` yourself.
      * Listening to the `notification` event and invoking
      * `popInitialNotification` is sufficient

--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.h
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.h
@@ -12,11 +12,17 @@
 
 @interface RNVoipPushNotificationManager : NSObject <RCTBridgeModule>
 
+typedef void (^RNVoipPushNotificationCompletion)(void);
+
+@property (nonatomic, strong) NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *completionHandlers;
+
 - (void)voipRegistration;
 - (void)registerUserNotification:(NSDictionary *)permissions;
 - (NSDictionary *)checkPermissions;
 + (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
 + (void)didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type;
 + (NSString *)getCurrentAppBackgroundState;
++ (void)addCompletionHandler:(NSString *)uuid completionHandler:(RNVoipPushNotificationCompletion)completionHandler;
++ (void)removeCompletionHandler:(NSString *)uuid;
 
 @end


### PR DESCRIPTION
## Motivation

From iOS 11+, we should use

```objc
(void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(PKPushType)type withCompletionHandler:(void (^)(void))completion
```

Apple asked us to call `completion()` when we've done the job.

I've observed that if we call `completion()` directly after `reportCallkit` on the native side in the same block of `didReceiveIncomingPushWithPayload`, since react native initialized asynchronously and we might have some works to do on the JS side to initiate a call, in this case, if we call `completion()` too early, it may cause our js job to stop executing. ( The system revoke the execution lock when we call `completion()` I guess. And seems different iOS version acts differently when call `completion()`)

This may be useful to someone.


## Usage:

https://github.com/react-native-webrtc/react-native-voip-push-notification/pull/52/commits/d519beed33bd7c15ac3db7a9fec7190da6a825ec