### PR TITLE
Refactor / Simplify Codes, support didLoadWithEvents

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, Ian Yu-Hsun Lin
+Copyright (c) 2016-2020, The react-native-voip-push-notification Contributors
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ class MyComponent extends React.Component {
             }
             for (let voipPushEvent of events) {
                 let { name, data } = voipPushEvent;
-                if (name === 'RNVoipPushRemoteNotificationsRegisteredEvent') {
+                if (name === VoipPushNotification.RNVoipPushRemoteNotificationsRegisteredEvent) {
                     this.onVoipPushNotificationRegistered(data);
-                } else if (name === 'RNVoipPushRemoteNotificationReceivedEvent') {
+                } else if (name === VoipPushNotification.RNVoipPushRemoteNotificationReceivedEvent) {
                     this.onVoipPushNotificationiReceived(data);
                 }
             }

--- a/README.md
+++ b/README.md
@@ -5,16 +5,6 @@
 
 React Native VoIP Push Notification - Currently iOS >= 8.0 only
 
-## Motivation
-
-Since iOS 8.0 there is an execellent feature called **VoIP Push Notification** ([PushKit][1]), while in React Native only the traditional push notification is supported which limits the possibilities of building a VoIP app with React Native (like me!).
-
-To understand the benefits of **Voip Push Notification**, please see [VoIP Best Practices][2].
-
-**Note 1**: Not sure if Android support this sort of stuff since I'm neither an iOS nor Android expert, from my limited understanding that GCM's [sending high priority push notification][5] might be the case. Correct me if I'm wrong!
-
-**Note 2** This module is inspired by [PushNotificationIOS][6] and [React Native Push Notification][7]
-
 ## RN Version
 
 * 1.1.0+ ( RN 40+ )
@@ -121,13 +111,7 @@ Make sure you enabled the folowing in `Xcode` -> `Signing & Capabilities`:
   // --- The system calls this method when a previously provided push token is no longer valid for use. No action is necessary on your part to reregister the push type. Instead, use this method to notify your server not to send push notifications using the matching push token.
 }
 
-
-// --- Handle incoming pushes (for ios <= 10)
-- (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(PKPushType)type {
-  [RNVoipPushNotificationManager didReceiveIncomingPushWithPayload:payload forType:(NSString *)type];
-}
-
-// --- Handle incoming pushes (for ios >= 11)
+// --- Handle incoming pushes
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(PKPushType)type withCompletionHandler:(void (^)(void))completion {
   
 
@@ -160,32 +144,32 @@ Make sure you enabled the folowing in `Xcode` -> `Signing & Capabilities`:
 ## Linking:
 
 On RN60+, auto linking with pod file should work.  
-Or you can try below:
+<details>
+  <summary>Linking Manually</summary>
 
-## Linking Manually:
-
-### Add PushKit Framework:
-
-- In your Xcode project, select `Build Phases` --> `Link Binary With Libraries`
-- Add `PushKit.framework`
-
-### Add RNVoipPushNotification:
-
-#### Option 1: Use [rnpm][3]
-
-```bash
-rnpm link react-native-voip-push-notification
-```
-
-**Note**: If you're using rnpm link make sure the `Header Search Paths` is `recursive`. (In step 3 of manually linking)
-
-#### Option 2: Manually
-
-1. Drag `node_modules/react-native-voip-push-notification/ios/RNVoipPushNotification.xcodeproj` under `<your_xcode_project>/Libraries`
-2. Select `<your_xcode_project>` --> `Build Phases` --> `Link Binary With Libraries`
-  - Drag `Libraries/RNVoipPushNotification.xcodeproj/Products/libRNVoipPushNotification.a` to `Link Binary With Libraries`
-3. Select `<your_xcode_project>` --> `Build Settings`
-  - In `Header Search Paths`, add `$(SRCROOT)/../node_modules/react-native-voip-push-notification/ios/RNVoipPushNotification` with `recursive`
+  ### Add PushKit Framework:
+  
+  - In your Xcode project, select `Build Phases` --> `Link Binary With Libraries`
+  - Add `PushKit.framework`
+  
+  ### Add RNVoipPushNotification:
+  
+  #### Option 1: Use [rnpm][3]
+  
+  ```bash
+  rnpm link react-native-voip-push-notification
+  ```
+  
+  **Note**: If you're using rnpm link make sure the `Header Search Paths` is `recursive`. (In step 3 of manually linking)
+  
+  #### Option 2: Manually
+  
+  1. Drag `node_modules/react-native-voip-push-notification/ios/RNVoipPushNotification.xcodeproj` under `<your_xcode_project>/Libraries`
+  2. Select `<your_xcode_project>` --> `Build Phases` --> `Link Binary With Libraries`
+    - Drag `Libraries/RNVoipPushNotification.xcodeproj/Products/libRNVoipPushNotification.a` to `Link Binary With Libraries`
+  3. Select `<your_xcode_project>` --> `Build Settings`
+    - In `Header Search Paths`, add `$(SRCROOT)/../node_modules/react-native-voip-push-notification/ios/RNVoipPushNotification` with `recursive`
+</details>
 
 ## Usage:
 
@@ -201,51 +185,48 @@ class MyComponent extends React.Component {
 
 ...
 
-  componentDidMount() { // or anywhere which is most comfortable and appropriate for you
-    VoipPushNotification.requestPermissions(); // --- optional, you can use another library to request permissions
-    VoipPushNotification.registerVoipToken(); // --- required
-  
-    VoipPushNotification.addEventListener('register', (token) => {
-      // --- send token to your apn provider server
-    });
+    // --- or anywhere which is most comfortable and appropriate for you, usually ASAP
+    componentDidMount() {
+        VoipPushNotification.registerVoipToken(); // --- register token
 
-    VoipPushNotification.addEventListener('localNotification', (notification) => {
-      // --- when user click local push
-    });
+        VoipPushNotification.addEventListener('didLoadWithEvents', (events) => {
+            // --- this will fire when there are events occured before js bridge initialized
+            // --- use this event to execute your event handler manually by event type
 
-    VoipPushNotification.addEventListener('notification', (notification) => {
-      // --- when receive remote voip push, register your VoIP client, show local notification ... etc
-      //this.doRegisterOrSomething();
+            if (!events || !Array.isArray(events) || events.length < 1) {
+                return;
+            }
+            for (let voipPushEvent of events) {
+                let { name, data } = voipPushEvent;
+                if (name === 'RNVoipPushRemoteNotificationsRegisteredEvent') {
+                    this.onVoipPushNotificationRegistered(data);
+                } else if (name === 'RNVoipPushRemoteNotificationReceivedEvent') {
+                    this.onVoipPushNotificationiReceived(data);
+                }
+            }
+        });
       
-       // --- This  is a boolean constant exported by this module
-       // --- you can use this constant to distinguish the app is launched by VoIP push notification or not
-       if (VoipPushNotification.wakeupByPush) {
-         // this.doSomething()
+        // --- onVoipPushNotificationRegistered
+        VoipPushNotification.addEventListener('register', (token) => {
+            // --- send token to your apn provider server
+        });
 
-         // --- remember to set this static variable back to false
-         // --- since the constant are exported only at initialization time, and it will keep the same in the whole app
-         VoipPushNotification.wakeupByPush = false;
-       }
+        // --- onVoipPushNotificationiReceived
+        VoipPushNotification.addEventListener('notification', (notification) => {
+            // --- when receive remote voip push, register your VoIP client, show local notification ... etc
+            this.doSomething();
+          
+            // --- optionally, if you `addCompletionHandler` from the native side, once you have done the js jobs to initiate a call, call `completion()`
+            VoipPushNotification.onVoipNotificationCompleted(notification.uuid);
+        });
+    }
 
-
-       // --- optionally, if you `addCompletionHandler` from the native side, once you have done the js jobs to initiate a call, call `completion()`
-       VoipPushNotification.onVoipNotificationCompleted(notification.getData().uuid);
-
-
-      /**
-       * Local Notification Payload
-       *
-       * - `alertBody` : The message displayed in the notification alert.
-       * - `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
-       * - `soundName` : The sound played when the notification is fired (optional).
-       * - `category`  : The category of this notification, required for actionable notifications (optional).
-       * - `userInfo`  : An optional object containing additional notification data.
-       */
-      VoipPushNotification.presentLocalNotification({
-          alertBody: "hello! " + notification.getMessage()
-      });
-    });
-  }
+    // --- unsubscribe event listeners
+    componentWillUnmount() {
+        VoipPushNotification.removeEventListener('didLoadWithEvents');
+        VoipPushNotification.removeEventListener('register');
+        VoipPushNotification.removeEventListener('notification');
+    }
 ...
 }
 
@@ -263,6 +244,3 @@ class MyComponent extends React.Component {
 [2]: https://developer.apple.com/library/ios/documentation/Performance/Conceptual/EnergyGuide-iOS/OptimizeVoIP.html
 [3]: https://github.com/rnpm/rnpm
 [4]: https://opensource.org/licenses/ISC
-[5]: https://developers.google.com/cloud-messaging/concept-options#setting-the-priority-of-a-message
-[6]: https://facebook.github.io/react-native/docs/pushnotificationios.html
-[7]: https://github.com/zo0r/react-native-push-notification

--- a/index.js
+++ b/index.js
@@ -2,37 +2,21 @@
 
 import {
     NativeModules,
-    DeviceEventEmitter,
+    NativeEventEmitter,
     Platform,
 } from 'react-native';
 
-var RNVoipPushNotificationManager = NativeModules.RNVoipPushNotificationManager;
-var invariant = require('fbjs/lib/invariant');
+const RNVoipPushNotificationManager = NativeModules.RNVoipPushNotificationManager;
 
-var _notifHandlers = new Map();
+const eventEmitter = new NativeEventEmitter(RNVoipPushNotificationManager);
+const _eventHandlers = new Map();
 
-var DEVICE_NOTIF_EVENT = 'voipRemoteNotificationReceived';
-var NOTIF_REGISTER_EVENT = 'voipRemoteNotificationsRegistered';
-var DEVICE_LOCAL_NOTIF_EVENT = 'voipLocalNotificationReceived';
+// --- native unique event names
+const RNVoipPushRemoteNotificationsRegisteredEvent = "RNVoipPushRemoteNotificationsRegisteredEvent"; // --- 'register'
+const RNVoipPushRemoteNotificationReceivedEvent = "RNVoipPushRemoteNotificationReceivedEvent"; // --- 'notification'
+const RNVoipPushDidLoadWithEvents = "RNVoipPushDidLoadWithEvents"; // --- 'didLoadWithEvents'
 
 export default class RNVoipPushNotification {
-
-    static wakeupByPush = (Platform.OS == 'ios' && RNVoipPushNotificationManager.wakeupByPush === 'true');
-
-    /**
-     * Schedules the localNotification for immediate presentation.
-     *
-     * details is an object containing:
-     *
-     * - `alertBody` : The message displayed in the notification alert.
-     * - `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
-     * - `soundName` : The sound played when the notification is fired (optional).
-     * - `category`  : The category of this notification, required for actionable notifications (optional).
-     * - `userInfo`  : An optional object containing additional notification data.
-     */
-    static presentLocalNotification(details) {
-        RNVoipPushNotificationManager.presentLocalNotification(details);
-    }
 
     /**
      * Attaches a listener to remote notification events while the app is running
@@ -40,89 +24,53 @@ export default class RNVoipPushNotification {
      *
      * Valid events are:
      *
-     * - `notification` : Fired when a remote notification is received. The
-     *   handler will be invoked with an instance of `PushNotificationIOS`.
-     * - `register`: Fired when the user registers for remote notifications. The
-     *   handler will be invoked with a hex string representing the deviceToken.
+     * - `notification` : Fired when a remote notification is received.
+     * - `register`: Fired when the user registers for remote notifications.
+     * - `didLoadWithEvents`: Fired when the user have initially subscribed any listener and has cached events already.
      */
     static addEventListener(type, handler) {
-        invariant(
-            type === 'notification' || type === 'register' || type === 'localNotification',
-            'RNVoipPushNotificationManager only supports `notification`, `register` and `localNotification` events'
-        );
-        var listener;
+        let listener;
         if (type === 'notification') {
-            listener = DeviceEventEmitter.addListener(
-                DEVICE_NOTIF_EVENT,
-                (notifData) => {
-                    handler(new RNVoipPushNotification(notifData));
-                }
-            );
-        } else if (type === 'localNotification') {
-            listener = DeviceEventEmitter.addListener(
-                DEVICE_LOCAL_NOTIF_EVENT,
-                (notifData) => {
-                    handler(new RNVoipPushNotification(notifData));
+            listener = eventEmitter.addListener(
+                RNVoipPushRemoteNotificationReceivedEvent,
+                (notificationPayload) => {
+                    handler(notificationPayload);
                 }
             );
         } else if (type === 'register') {
-            listener = DeviceEventEmitter.addListener(
-                NOTIF_REGISTER_EVENT,
-                (registrationInfo) => {
-                    handler(registrationInfo.deviceToken);
+            listener = eventEmitter.addListener(
+                RNVoipPushRemoteNotificationsRegisteredEvent,
+                (deviceToken) => {
+                    handler(deviceToken);
                 }
             );
+        } else if (type === 'didLoadWithEvents') {
+            listener = eventEmitter.addListener(
+                RNVoipPushDidLoadWithEvents,
+                (events) => {
+                    handler(events);
+                }
+            );
+        } else {
+            return;
         }
-        _notifHandlers.set(handler, listener);
+
+        // --- we only support one listener at a time, remove to prevent leak
+        RNVoipPushNotification.removeEventListener(type);
+        _eventHandlers.set(type, listener);
     }
 
     /**
      * Removes the event listener. Do this in `componentWillUnmount` to prevent
      * memory leaks
      */
-    static removeEventListener(type, handler) {
-        invariant(
-            type === 'notification' || type === 'register' || type === 'localNotification',
-            'RNVoipPushNotification only supports `notification`, `register` and `localNotification` events'
-        );
-        var listener = _notifHandlers.get(handler);
+    static removeEventListener(type) {
+        let listener = _eventHandlers.get(type);
         if (!listener) {
             return;
         }
         listener.remove();
-        _notifHandlers.delete(handler);
-    }
-
-    /**
-     * Requests notification permissions from iOS, prompting the user's
-     * dialog box. By default, it will request all notification permissions, but
-     * a subset of these can be requested by passing a map of requested
-     * permissions.
-     * The following permissions are supported:
-     *
-     *   - `alert`
-     *   - `badge`
-     *   - `sound`
-     *
-     * If a map is provided to the method, only the permissions with truthy values
-     * will be requested.
-     */
-    static requestPermissions(permissions) {
-        var requestedPermissions = {};
-        if (permissions) {
-            requestedPermissions = {
-                alert: !!permissions.alert,
-                badge: !!permissions.badge,
-                sound: !!permissions.sound
-            };
-        } else {
-            requestedPermissions = {
-                alert: true,
-                badge: true,
-                sound: true
-            };
-        }
-        RNVoipPushNotificationManager.requestPermissions(requestedPermissions);
+        _eventHandlers.delete(type);
     }
 
     /**
@@ -150,63 +98,4 @@ export default class RNVoipPushNotification {
         RNVoipPushNotificationManager.onVoipNotificationCompleted(uuid);
     }
 
-    /**
-     * You will never need to instantiate `RNVoipPushNotification` yourself.
-     * Listening to the `notification` event and invoking
-     * `popInitialNotification` is sufficient
-     */
-    constructor(nativeNotif) {
-        this._data = {};
-  
-        // Extract data from Apple's `aps` dict as defined:
-  
-        // https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html
-  
-        Object.keys(nativeNotif).forEach((notifKey) => {
-            var notifVal = nativeNotif[notifKey];
-            if (notifKey === 'aps') {
-                this._alert = notifVal.alert;
-                this._sound = notifVal.sound;
-                this._badgeCount = notifVal.badge;
-            } else {
-                this._data[notifKey] = notifVal;
-            }
-        });
-    }
-
-    /**
-     * An alias for `getAlert` to get the notification's main message string
-     */
-    getMessage() {
-        // alias because "alert" is an ambiguous name
-        return this._alert;
-    }
-  
-    /**
-     * Gets the sound string from the `aps` object
-     */
-    getSound() {
-        return this._sound;
-    }
-  
-    /**
-     * Gets the notification's main message from the `aps` object
-     */
-    getAlert() {
-        return this._alert;
-    }
-  
-    /**
-     * Gets the badge count number from the `aps` object
-     */
-    getBadgeCount() {
-        return this._badgeCount;
-    }
-  
-    /**
-     * Gets the data object on the notif
-     */
-    getData() {
-        return this._data;
-    }
 }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,18 @@ const RNVoipPushDidLoadWithEvents = "RNVoipPushDidLoadWithEvents"; // --- 'didLo
 
 export default class RNVoipPushNotification {
 
+    static get RNVoipPushRemoteNotificationsRegisteredEvent() {
+        return RNVoipPushRemoteNotificationsRegisteredEvent;
+    }
+
+    static get RNVoipPushRemoteNotificationReceivedEvent() {
+        return RNVoipPushRemoteNotificationReceivedEvent;
+    }
+
+    static get RNVoipPushDidLoadWithEvents() {
+        return RNVoipPushDidLoadWithEvents;
+    }
+
     /**
      * Attaches a listener to remote notification events while the app is running
      * in the foreground or the background.

--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.h
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.h
@@ -17,6 +17,7 @@ typedef void (^RNVoipPushNotificationCompletion)(void);
 
 @property (nonatomic, strong) NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *completionHandlers;
 
++ (void)voipRegistration;
 + (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
 + (void)didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type;
 + (void)addCompletionHandler:(NSString *)uuid completionHandler:(RNVoipPushNotificationCompletion)completionHandler;

--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.h
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.h
@@ -2,8 +2,9 @@
 //  RNVoipPushNotificationManager.h
 //  RNVoipPushNotification
 //
-//  Created by Ian Yu-Hsun Lin on 4/18/16.
-//  Copyright © 2016 ianyuhsunlin. All rights reserved.
+//  Copyright 2016-2020 The react-native-voip-push-notification Contributors
+//  see: https://github.com/react-native-webrtc/react-native-voip-push-notification/graphs/contributors
+//  SPDX-License-Identifier: ISC, MIT
 //
 
 #import <Foundation/Foundation.h>

--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.h
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.h
@@ -7,21 +7,17 @@
 //
 
 #import <Foundation/Foundation.h>
-
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface RNVoipPushNotificationManager : NSObject <RCTBridgeModule>
+@interface RNVoipPushNotificationManager : RCTEventEmitter <RCTBridgeModule>
 
 typedef void (^RNVoipPushNotificationCompletion)(void);
 
 @property (nonatomic, strong) NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *completionHandlers;
 
-- (void)voipRegistration;
-- (void)registerUserNotification:(NSDictionary *)permissions;
-- (NSDictionary *)checkPermissions;
 + (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
 + (void)didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type;
-+ (NSString *)getCurrentAppBackgroundState;
 + (void)addCompletionHandler:(NSString *)uuid completionHandler:(RNVoipPushNotificationCompletion)completionHandler;
 + (void)removeCompletionHandler:(NSString *)uuid;
 

--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
@@ -2,8 +2,9 @@
 //  RNVoipPushNotificationManager.m
 //  RNVoipPushNotification
 //
-//  Created by Ian Yu-Hsun Lin on 4/18/16.
-//  Copyright © 2016 ianyuhsunlin. All rights reserved.
+//  Copyright 2016-2020 The react-native-voip-push-notification Contributors
+//  see: https://github.com/react-native-webrtc/react-native-voip-push-notification/graphs/contributors
+//  SPDX-License-Identifier: ISC, MIT
 //
 
 #import <PushKit/PushKit.h>


### PR DESCRIPTION
## Breaking Change

This PR does the following:

* remove unused codes, keep this lib simple, lots functionalities should be easily implemented in the modern RN eco system
  - remove requestPermission ( use `PushNotificationIOS` instead )
  - remove getting background state ( use `AppState` instead )

* use `NativeEventEmitter` instead the deprecated `DeviceEventEmitter`

* tweak event handler logic

* support caching events before js initialize
  you can subscribe `didLoadWithEvents` when app ready

## About didLoadWithEvents

This is aim to fix #59 ( voip push received and the event fired before js initialized  )

@JJMoon proposed a workaround like in PR #65 and a proper fix in PR #61 
Thanks!

But then I tend to use a different way which is the same with react-native-webrtc/react-native-callkeep/pull/205

The reason:

* Instead using a promise method to get events directly, using event based with `startObserving`, we can make sure the bridge is up and READY for events, and this may prevent edge case between get initial events and subsequently fired events.

* We cache events if js is not up, this can be work together with, if you would like to use `voipRegistration` directly in `didFnishLaunchingWithOptions` in `AppDelegate.m`. This is described in https://github.com/react-native-webrtc/react-native-voip-push-notification/issues/59#issuecomment-691685841 by @chevonc . Not sure but I believe that helps in some situation. (We don't know how exactly PushKit works and when will it DELIVER voip push to us happily.)

## Side question and discussion

The thing I can not figure out is, when app killed, and the app can be wake up by the remote push and enter the `didFnishLaunchingWithOptions`, doesn't that mean we already have a valid voip token to RECEIVE voip push?

Does PushKit invoke `didReceiveIncomingPushWithPayload` only when we have registered voip token?
Do we recommend to move `voipRegistration` in `didFnishLaunchingWithOptions` in `AppDelegate.m`?



