### PR TITLE
cache lastVoipToken and return it when subsequently call to registerVoipToken

### DIFF
--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
@@ -29,6 +29,7 @@ NSString *const RNVoipPushDidLoadWithEvents = @"RNVoipPushDidLoadWithEvents";
 RCT_EXPORT_MODULE();
 
 static bool _isVoipRegistered = NO;
+static NSString *_lastVoipToken = @"";
 static NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *completionHandlers = nil;
 
 
@@ -125,8 +126,10 @@ static NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *comple
 {
     if (_isVoipRegistered) {
 #ifdef DEBUG
-        RCTLog(@"[RNVoipPushNotificationManager] voipRegistration is already registered");
+        RCTLog(@"[RNVoipPushNotificationManager] voipRegistration is already registered. return _lastVoipToken = %@", _lastVoipToken);
 #endif
+        RNVoipPushNotificationManager *voipPushManager = [RNVoipPushNotificationManager allocWithZone: nil];
+        [voipPushManager sendEventWithNameWrapper:RNVoipPushRemoteNotificationsRegisteredEvent body:_lastVoipToken];
     } else {
         _isVoipRegistered = YES;
 #ifdef DEBUG
@@ -161,8 +164,10 @@ static NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *comple
         [hexString appendFormat:@"%02x", bytes[i]];
     }
 
+    _lastVoipToken = [hexString copy];
+
     RNVoipPushNotificationManager *voipPushManager = [RNVoipPushNotificationManager allocWithZone: nil];
-    [voipPushManager sendEventWithNameWrapper:RNVoipPushRemoteNotificationsRegisteredEvent body:[hexString copy]];
+    [voipPushManager sendEventWithNameWrapper:RNVoipPushRemoteNotificationsRegisteredEvent body:_lastVoipToken];
 }
 
 // --- should be called from `AppDelegate.didReceiveIncomingPushWithPayload`

--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
@@ -11,10 +11,8 @@
 #import "RNVoipPushNotificationManager.h"
 
 #import <React/RCTBridge.h>
-#import <React/RCTConvert.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTLog.h>
-#import <React/RCTUtils.h>
 
 NSString *const RNVoipPushRemoteNotificationsRegisteredEvent = @"RNVoipPushRemoteNotificationsRegisteredEvent";
 NSString *const RNVoipPushRemoteNotificationReceivedEvent = @"RNVoipPushRemoteNotificationReceivedEvent";


### PR DESCRIPTION
We should prevent register duplicated delegate to PushKit. So if you have registered `voipRegistration` on the native side, when you call `registerVoipToken` on the js side again, it will prevent it to register twice, and is a no op. 

But for compatibility and convenience, now we cached `the latest voip token` on the native side each time we received token from PushKit inside `didUpdatePushCredentials`, and, if user call `registerVoipToken` and it's registered already, it will fire `register` event with the latest cached voip token then.