### PR TITLE
Fixed bug preventing delayed events from working

### DIFF
--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
@@ -39,7 +39,9 @@ static NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *comple
 - (instancetype)init
 {
     if (self = [super init]) {
-        _delayedEvents = [NSMutableArray array];
+        if (_delayedEvents == nil) {
+            _delayedEvents = [NSMutableArray array];
+        }
     }
     return self;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-voip-push-notification",
-  "version": "3.1.0",
+  "version": "3.1.1-rc1",
   "description": "VoIP push notification on react-native",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-voip-push-notification",
-  "version": "3.1.1-rc1",
+  "version": "3.1.0",
   "description": "VoIP push notification on react-native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When using `[RNVoipPushNotificationManager voipRegistration];` in `AppDelegate.m` the `RNVoipPushNotificationManager.m` constructor (or init function or whatever Objective-C calls this), is executed twice, once I suppose by us interacting with RNVoipPushNotificationManager prior to the RN Bridge having instantiated it, and then again later when the bridge is going to use it and start observing.

The initialization process is a bit of a mystery to me, but in any regard, the `_delayedEvents` array is overridden by the 2nd initialization, causing us to loose all the delayed events, effectively causing `didLoadWithEvents` to never fire, and the events being lost in the void that exists between IOS and React Native :(

This fixes that, but as I'm not really an objective-c developer, I don't know if I'm just hacking this together, instead of addressing some underlaying issue.