### PR TITLE
Hot reload stop observing issue

### DIFF
--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
@@ -39,12 +39,8 @@ static NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *comple
 }
 
 -(instancetype) initPrivate {
-    self = [super init];
-    if (self) {
-        // Initialization code here.
-        _delayedEvents = [NSMutableArray array];
-    }
-    return self;
+    _delayedEvents = [NSMutableArray array];
+    return [super init];
 }
 
 // Singletone implementation based on https://stackoverflow.com/q/5720029/3686678 and https://stackoverflow.com/a/7035136/3686678
@@ -95,18 +91,12 @@ static NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *comple
 {
     _hasListeners = YES;
     if ([_delayedEvents count] > 0) {
-        // RCTLog(@"[RNVoipPushNotificationManager] sendEventWithName _hasListeners = %d name = %@", _hasListeners, RNVoipPushDidLoadWithEvents);
         [self sendEventWithName:RNVoipPushDidLoadWithEvents body:_delayedEvents];
     }
 }
 
 - (void)stopObserving
 {
-#ifdef DEBUG
-    // RCTLog(@"[RNVoipPushNotificationManager] skip stopObserving because in debug mode startObserving is not called on reload, but stopObserving is called before reload");
-    return;
-#endif
-
     _hasListeners = NO;
 }
 
@@ -118,7 +108,6 @@ static NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *comple
 
 // --- send directly if has listeners, cache it otherwise
 - (void)sendEventWithNameWrapper:(NSString *)name body:(id)body {
-    // RCTLog(@"[RNVoipPushNotificationManager] sendEventWithNameWrapper _hasListeners = %d  name = %@", _hasListeners, name);
     if (_hasListeners) {
         [self sendEventWithName:name body:body];
     } else {

--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
@@ -97,6 +97,11 @@ static NSMutableDictionary<NSString *, RNVoipPushNotificationCompletion> *comple
 
 - (void)stopObserving
 {
+// Skip stopObserving because in debug mode startObserving is not called on reload, but stopObserving is called before reload
+#ifdef DEBUG
+    return;
+#endif
+
     _hasListeners = NO;
 }
 


### PR DESCRIPTION
Skip stopObserving because in debug mode startObserving is not called on reload, but stopObserving is called before reload.

My application fetch voip token every time on start, but when working on UI with hot reload I have an annoying warning that voip token was not fetched from native code. That is because somehow on hot reload stopObserving is called, but then no startObserving is called. This might be some react-native issue.

So I think this code does not have any harm, but fix unexpected react-native observer behaviour.

If anyone has any objection please let me know.