### PR TITLE
Types: Describe event handlers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,33 @@
 declare module 'react-native-voip-push-notification' {
-    export type Events =
-    'notification' |
-    'register'|
-    'didLoadWithEvents';
+    export type NativeEvents = {
+        register: 'RNVoipPushRemoteNotificationsRegisteredEvent';
+        notification: 'RNVoipPushRemoteNotificationReceivedEvent';
+        didLoadWithEvents: 'RNVoipPushDidLoadWithEvents';
+    }
+
+    export type Events = keyof NativeEvents;
+    export type EventsPayload = {
+        register: string,
+        notification: object,
+        didLoadWithEvents: Array<InitialEvent>,
+    }
+
+    export type InitialEvent = {
+        [Event in Events]: { name: NativeEvents[Event], data: EventsPayload[Event] }
+    }[Events];
 
     export default class RNVoipPushNotification {
-        static addEventListener(type: Events, handler: (args: any) => void): void
+        static RNVoipPushRemoteNotificationsRegisteredEvent: NativeEvents['register']
+        static RNVoipPushRemoteNotificationReceivedEvent: NativeEvents['notification']
+        static RNVoipPushDidLoadWithEvents: NativeEvents['didLoadWithEvents']
+
+        static addEventListener<Event extends Events>(
+            type: Event,
+            handler: (args: EventsPayload[Event]) => void,
+        ): void
+        static removeEventListener(type: Events): void
+
         static registerVoipToken(): void;
         static onVoipNotificationCompleted(uuid: string): void;
-        static removeEventListener(type: Events): void
     }
 }


### PR DESCRIPTION
Have described the payloads for the event listeners based on the docs.

This eliminates the use of "any" in the type definitions.